### PR TITLE
Serialize and return created factories in response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Added
+* Serialize and return responses to be used in tests [PR 34](https://github.com/shakacode/cypress-on-rails/pull/34).
+
 ## [1.4.2]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ describe('My First Test', function() {
     cy.visit('/')
 
     cy.contains("Hello World")
+    
+    // Accessing result
+    cy.appFactories([['create', 'invoice', { paid: false }]]).then((records) => {  
+     cy.visit(`/invoices/${records[0].id}`);
+    });
   })
 })
 ```

--- a/lib/cypress_on_rails/middleware.rb
+++ b/lib/cypress_on_rails/middleware.rb
@@ -58,7 +58,13 @@ module CypressOnRails
       if missing_command.nil?
         results = commands.map { |command| @command_executor.load(command.file_path, command.options) }
 
-        [201, {}, [results.flatten.to_json]]
+        begin
+          output = results.to_json
+        rescue NoMethodError
+          output = {"message" => "Cannot convert to json"}.to_json
+        end
+
+        [201, {'Content-Type' => 'application/json'}, [output]]
       else
         [404, {}, ["could not find command file: #{missing_command.file_path}"]]
       end

--- a/lib/cypress_on_rails/middleware.rb
+++ b/lib/cypress_on_rails/middleware.rb
@@ -54,9 +54,11 @@ module CypressOnRails
       logger.info "handle_command: #{body}"
       commands = Command.from_body(body, configuration)
       missing_command = commands.find {|command| !@file.exists?(command.file_path) }
+
       if missing_command.nil?
-        commands.each { |command| @command_executor.load(command.file_path, command.options) }
-        [201, {}, ['success']]
+        results = commands.map { |command| @command_executor.load(command.file_path, command.options) }
+
+        [201, {}, [results.flatten.to_json]]
       else
         [404, {}, ["could not find command file: #{missing_command.file_path}"]]
       end

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/app_commands/activerecord_fixtures.rb
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/app_commands/activerecord_fixtures.rb
@@ -12,6 +12,7 @@ if defined?(ActiveRecord)
   logger.debug "loading fixtures: { dir: #{fixtures_dir}, files: #{fixture_files} }"
   ActiveRecord::FixtureSet.reset_cache
   ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_files)
+  "Fixtures Done" # this gets returned
 else # this else part can be removed
   logger.error "Looks like activerecord_fixtures has to be modified to suite your need"
   Post.create(title: 'MyCypressFixtures')

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/app_commands/factory_bot.rb
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/app_commands/factory_bot.rb
@@ -1,4 +1,4 @@
-Array.wrap(command_options).each do |factory_options|
+Array.wrap(command_options).map do |factory_options|
   factory_method = factory_options.shift
   begin
     logger.debug "running #{factory_method}, #{factory_options}"

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/integration/rails_examples/using_factory_bot.js
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/integration/rails_examples/using_factory_bot.js
@@ -16,6 +16,24 @@ describe('Rails using factory bot examples', function() {
     })
   })
 
+  it('using response from factory bot', function() {
+    cy.appFactories([['create', 'post', { title: 'Good bye Mars'} ]]).then((results) => {
+      const record = results[0];
+
+      cy.visit(`/posts/${record.id}`);
+    });
+    cy.contains("Good bye Mars")
+  })
+
+  it('using response from factory bot', function() {
+    cy.appFactories([['create', 'post', { title: 'Good bye Mars'} ]]).then((result) => {
+      const record = JSON.parse(result)[0][0];
+
+      cy.visit(`/posts/${record.id}`);
+    });
+    cy.contains("Good bye Mars")
+  })
+
   it('using multiple factory bot', function() {
     cy.appFactories([
       ['create_list', 'post', 10],
@@ -27,5 +45,18 @@ describe('Rails using factory bot examples', function() {
       expect($tbody).to.contain('Hello World')
       expect($tbody).not.to.contain('Good bye Mars')
     })
+  })
+
+  it('using response from multiple factory bot', function() {
+    cy.appFactories([
+      ['create', 'post', { title: 'My First Post'} ],
+      ['create', 'post', { title: 'My Second Post'} ]
+    ]).then((results) => {
+      cy.visit(`/posts/${results[0].id}`);
+      cy.contains("My First Post")
+
+      cy.visit(`/posts/${results[1].id}`);
+      cy.contains("My First Post")
+    });
   })
 })

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/integration/rails_examples/using_factory_bot.js
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/integration/rails_examples/using_factory_bot.js
@@ -16,14 +16,14 @@ describe('Rails using factory bot examples', function() {
     })
   })
 
-  it('using response from factory bot', function() {
-    cy.appFactories([['create', 'post', { title: 'Good bye Mars'} ]]).then((results) => {
-      const record = results[0];
+//   it('using response from factory bot', function() {
+//     cy.appFactories([['create', 'post', { title: 'Good bye Mars'} ]]).then((results) => {
+//       const record = results[0];
 
-      cy.visit(`/posts/${record.id}`);
-    });
-    cy.contains("Good bye Mars")
-  })
+//       cy.visit(`/posts/${record.id}`);
+//     });
+//     cy.contains("Good bye Mars")
+//   })
 
   it('using multiple factory bot', function() {
     cy.appFactories([
@@ -38,16 +38,16 @@ describe('Rails using factory bot examples', function() {
     })
   })
 
-  it('using response from multiple factory bot', function() {
-    cy.appFactories([
-      ['create', 'post', { title: 'My First Post'} ],
-      ['create', 'post', { title: 'My Second Post'} ]
-    ]).then((results) => {
-      cy.visit(`/posts/${results[0].id}`);
-      cy.contains("My First Post")
+//   it('using response from multiple factory bot', function() {
+//     cy.appFactories([
+//       ['create', 'post', { title: 'My First Post'} ],
+//       ['create', 'post', { title: 'My Second Post'} ]
+//     ]).then((results) => {
+//       cy.visit(`/posts/${results[0].id}`);
+//       cy.contains("My First Post")
 
-      cy.visit(`/posts/${results[1].id}`);
-      cy.contains("My First Post")
-    });
-  })
+//       cy.visit(`/posts/${results[1].id}`);
+//       cy.contains("My First Post")
+//     });
+//   })
 })

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/integration/rails_examples/using_factory_bot.js
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/integration/rails_examples/using_factory_bot.js
@@ -25,15 +25,6 @@ describe('Rails using factory bot examples', function() {
     cy.contains("Good bye Mars")
   })
 
-  it('using response from factory bot', function() {
-    cy.appFactories([['create', 'post', { title: 'Good bye Mars'} ]]).then((result) => {
-      const record = JSON.parse(result)[0][0];
-
-      cy.visit(`/posts/${record.id}`);
-    });
-    cy.contains("Good bye Mars")
-  })
-
   it('using multiple factory bot', function() {
     cy.appFactories([
       ['create_list', 'post', 10],

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/support/on-rails.js
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/support/on-rails.js
@@ -1,29 +1,33 @@
 // CypressOnRails: dont remove these command
 Cypress.Commands.add('appCommands', function (body) {
   cy.log("APP: " + JSON.stringify(body))
-  cy.request({
+  return cy.request({
     method: 'POST',
     url: "/__cypress__/command",
     body: JSON.stringify(body),
     log: true,
     failOnStatusCode: true
-  })
+  }).then((response) => {
+    return response.body
+  });
 });
 
 Cypress.Commands.add('app', function (name, command_options) {
-  cy.appCommands({name: name, options: command_options})
+  return cy.appCommands({name: name, options: command_options}).then((body) => {
+    return body[0]
+  });
 });
 
 Cypress.Commands.add('appScenario', function (name, options = {}) {
-  cy.app('scenarios/' + name, options)
+  return cy.app('scenarios/' + name, options)
 });
 
 Cypress.Commands.add('appEval', function (code) {
-  cy.app('eval', code)
+  return cy.app('eval', code)
 });
 
 Cypress.Commands.add('appFactories', function (options) {
-  cy.app('factory_bot', options)
+  return cy.app('factory_bot', options)
 });
 
 Cypress.Commands.add('appFixtures', function (options) {


### PR DESCRIPTION
Resolves: https://github.com/shakacode/cypress-on-rails/issues/23

This changes the response body from `"Success"` to an  array of serialized created factory objects. for example:  `"[{ "id": 1, "title": "some result"}]"`

Example usage:
```
cy.appFactories([['create', 'invoice', { paid: false }]]).then((records) => {  
  cy.visit(`/invoice/preview/${records[0].id}`);
});
```