### PR TITLE
Improve eval() in command executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Changed
+*  Improve eval() in command executor [PR 46](https://github.com/shakacode/cypress-on-rails/pull/46) by [Systho](https://github.com/Systho)
+
 ## [1.5.1]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.5.0...v1.5.1
 

--- a/lib/cypress_on_rails/command_executor.rb
+++ b/lib/cypress_on_rails/command_executor.rb
@@ -6,7 +6,7 @@ module CypressOnRails
     def self.load(file,command_options = nil)
       load_cypress_helper
       file_data = File.read(file)
-      eval file_data
+      eval file_data, binding, file
     rescue => e
       logger.error("fail to execute #{file}: #{e.message}")
       logger.error(e.backtrace.join("\n"))


### PR DESCRIPTION
allow eval to use correct filename, this will produce better stacktrace and allow things like `require_relative` in eval'd files