### PR TITLE
Change default port to 5017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Changed
+* Change default port to 5017 [PR 49](https://github.com/shakacode/cypress-on-rails/pull/49)
+
 ## [1.5.1]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.5.0...v1.5.1
 
@@ -32,7 +35,7 @@
 * Update Travis CI badge in README [PR 31](https://github.com/shakacode/cypress-on-rails/pull/31)
 * Fix CI by Installing cypress dependencies on Travis CI [PR 31](https://github.com/shakacode/cypress-on-rails/pull/31)
 
-## [1.4.0] 
+## [1.4.0]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.3.0...v1.4.0
 
 * Accept an options argument for scenarios. [PR 18](https://github.com/shakacode/cypress-on-rails/pull/18) by [ericraio](https://github.com/ericraio).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is sponsored by the software consulting firm [ShakaCode](https://ww
 
 ----
 
-Gem for using [cypress.io](http://github.com/cypress-io/) in Rails and ruby rack applications 
+Gem for using [cypress.io](http://github.com/cypress-io/) in Rails and ruby rack applications
 with the goal of controlling State as mentioned in [Cypress Best Practices](https://docs.cypress.io/guides/references/best-practices.html#Organizing-Tests-Logging-In-Controlling-State)
 
 It allows to run code in the application context when executing cypress tests.
@@ -75,7 +75,7 @@ Start the rails server in test mode and start cypress
 ```shell
 # start rails
 RAILS_ENV=test bin/rake db:create db:schema:load
-bin/rails server -e test -p 5002
+bin/rails server -e test -p 5017
 
 # in separate window start cypress
 yarn cypress open --project ./spec
@@ -92,7 +92,7 @@ CypressOnRails::SmartFactoryWrapper.configure(
   always_reload: !Rails.configuration.cache_classes,
   factory: FactoryBot,
   files: Dir['./spec/factories/**/*.rb']
-) 
+)
 ```
 
 ```js
@@ -109,9 +109,9 @@ describe('My First Test', function() {
     cy.visit('/')
 
     cy.contains("Hello World")
-    
+
     // Accessing result
-    cy.appFactories([['create', 'invoice', { paid: false }]]).then((records) => {  
+    cy.appFactories([['create', 'invoice', { paid: false }]]).then((records) => {
      cy.visit(`/invoices/${records[0].id}`);
     });
   })
@@ -156,7 +156,7 @@ You define a scenario in the `spec/cypress/app_commands/scenarios` directory:
 Profile.create name: "Cypress Hill"
 
 # or if you have factory_bot enabled in your cypress_helper
-CypressOnRails::SmartFactoryWrapper.create(:profile, name: "Cypress Hill") 
+CypressOnRails::SmartFactoryWrapper.create(:profile, name: "Cypress Hill")
 ```
 
 Then reference the scenario in your test:
@@ -178,8 +178,8 @@ describe('My First Test', function() {
 
 create a ruby file in `spec/cypress/app_commands` directory:
 ```ruby
-# spec/cypress/app_commands/load_seed.rb 
-load "#{Rails.root}/db/seeds.rb" 
+# spec/cypress/app_commands/load_seed.rb
+load "#{Rails.root}/db/seeds.rb"
 ```
 
 Then reference the command in your test with `cy.app('load_seed')`:
@@ -187,7 +187,7 @@ Then reference the command in your test with `cy.app('load_seed')`:
 // spec/cypress/integrations/simple_spec.js
 describe('My First Test', function() {
   beforeEach(() => { cy.app('load_seed') })
-  
+
   it('visit root', function() {
     cy.visit('/')
 
@@ -210,7 +210,7 @@ CypressOnRails.configure do |c|
 end
 use CypressOnRails::Middleware
 
-run MyApp 
+run MyApp
 ```
 
 add the following file to cypress

--- a/lib/generators/cypress_on_rails/templates/spec/cypress.json
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress.json
@@ -1,4 +1,4 @@
 {
-  "baseUrl": "http://localhost:5002",
+  "baseUrl": "http://localhost:5017",
   "defaultCommandTimeout": 10000
 }

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/integration/examples/cypress_api.spec.js
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/integration/examples/cypress_api.spec.js
@@ -112,7 +112,7 @@ context('Cypress.config()', () => {
     let myConfig = Cypress.config()
 
     expect(myConfig).to.have.property('animationDistanceThreshold', 5)
-    expect(myConfig).to.have.property('baseUrl', 'http://localhost:5002')
+    expect(myConfig).to.have.property('baseUrl', 'http://localhost:5017')
     expect(myConfig).to.have.property('defaultCommandTimeout', 10000)
     expect(myConfig).to.have.property('requestTimeout', 5000)
     expect(myConfig).to.have.property('responseTimeout', 30000)

--- a/spec/integrations/cypress.json
+++ b/spec/integrations/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:5002",
+  "baseUrl": "http://localhost:5017",
   "defaultCommandTimeout": 10000,
   "projectId": "qvzwep"
 }

--- a/spec/integrations/rails_3_2/test.sh
+++ b/spec/integrations/rails_3_2/test.sh
@@ -21,7 +21,7 @@ echo '-- start rails server'
 # make sure the server is not running
 (kill -9 `cat tmp/pids/server.pid` || true )
 
-bundle exec ./bin/rails server -p 5002 -e test &
+bundle exec ./bin/rails server -p 5017 -e test &
 sleep 2 # give rails a chance to start up correctly
 
 echo '-- cypress run'

--- a/spec/integrations/rails_4_2/test.sh
+++ b/spec/integrations/rails_4_2/test.sh
@@ -21,7 +21,7 @@ echo '-- start rails server'
 # make sure the server is not running
 (kill -9 `cat tmp/pids/server.pid` || true )
 
-bundle exec ./bin/rails server -p 5002 -e test &
+bundle exec ./bin/rails server -p 5017 -e test &
 sleep 2 # give rails a chance to start up correctly
 
 echo '-- cypress run'

--- a/spec/integrations/rails_5_2/test.sh
+++ b/spec/integrations/rails_5_2/test.sh
@@ -23,7 +23,7 @@ echo '-- start rails server'
 # make sure the server is not running
 (kill -9 `cat tmp/pids/server.pid` || true )
 
-bundle exec ./bin/rails server -p 5002 -e test &
+bundle exec ./bin/rails server -p 5017 -e test &
 sleep 2 # give rails a chance to start up correctly
 
 echo '-- cypress run'


### PR DESCRIPTION
Fixes #20

This port number was selected on random from a port range 5016-5019.

More info: https://github.com/shakacode/cypress-on-rails/issues/20

According to [this list](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt) there are a few ranges of ports that are not assigned, the closest to the current setting is 5016-5019, and this [wikipedia page](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers) seems to confirm it.

The way I got port 5017 was by "rolling the dice" in pry console:

```rb
 >  (5016..5019).to_a
[
  5016,
  5017,
  5018,
  5019
]
 >  (5016..5019).to_a.sample
5017
```

I ran this code exactly once. :)