### PR TITLE
Mention the correct file logger in the warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Change default port to 5017 [PR 49](https://github.com/shakacode/cypress-on-rails/pull/49) by [vfonic](https://github/vfonic)
 
 ### Fixed
-* fix file location warning message in clean.rb [PR 54](https://github.com/shakacode/cypress-on-rails/pull/43) by [ootoovak](https://github.com/ootoovak)
+* fix file location warning message in clean.rb [PR 54](https://github.com/shakacode/cypress-on-rails/pull/54) by [ootoovak](https://github.com/ootoovak)
 
 ## [1.5.1]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.5.0...v1.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changed
-* Change default port to 5017 [PR 49](https://github.com/shakacode/cypress-on-rails/pull/49)
+* Change default port to 5017 [PR 49](https://github.com/shakacode/cypress-on-rails/pull/49) by [vfonic](https://github/vfonic)
+
+### Fixed
+* fix file location warning message in clean.rb [PR 54](https://github.com/shakacode/cypress-on-rails/pull/43) by [ootoovak](https://github.com/ootoovak)
 
 ## [1.5.1]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.5.0...v1.5.1

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/app_commands/clean.rb
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/app_commands/clean.rb
@@ -3,7 +3,7 @@ if defined?(DatabaseCleaner)
   DatabaseCleaner.strategy = :truncation
   DatabaseCleaner.clean
 else
-  logger.warn "add database_cleaner or update clean_db"
+  logger.warn "add database_cleaner or update cypress/app_commands/clean.rb"
   Post.delete_all if defined?(Post)
 end
 


### PR DESCRIPTION
The clean_db file no seems to have been renamed to just clean. I've changed to to the correct file name and because clean is a common word I've added more of the path to make it obvious it is referring to a file and to direct the user reading the warning to the right place.