### PR TITLE
Update the Rails test server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Start the rails server in test mode and start cypress
 ```shell
 # start rails
 RAILS_ENV=test bin/rake db:create db:schema:load
-bin/rails server -e test -p 5017
+bin/rails server -e test -p 5002
 
 # in separate window start cypress
 yarn cypress open --project ./spec


### PR DESCRIPTION
Running the next command `yarn cypress open --project ./spec` starts up Cypress which seems to look for a server responding on port `5002` by default rather than the previously documented `bin/rails server -e test -p 5017`. This fix updates the documentation to get the Rails test server running on the port that Cypress expects it to be responding on, `5002`.
<img width="912" alt="Screen Shot 2020-04-13 at 2 11 09 PM" src="https://user-images.githubusercontent.com/105251/79086836-9f073100-7d91-11ea-965e-26fafb914dea.png">