### PR TITLE
Add middleware after load_config_initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+[Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.6.0...master
+
+### Fixed
+* Add middleware after load_config_initializers [PR 62](https://github.com/shakacode/cypress-on-rails/pull/62) by [duytd](https://github.com/duytd)
+
 ## [1.6.0]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.5.1...v1.6.0
 

--- a/lib/cypress_on_rails/railtie.rb
+++ b/lib/cypress_on_rails/railtie.rb
@@ -4,7 +4,7 @@ require 'cypress_on_rails/middleware'
 
 module CypressOnRails
   class Railtie < Rails::Railtie
-    initializer :setup_cypress_middleware do |app|
+    initializer :setup_cypress_middleware, after: :load_config_initializers do |app|
       if CypressOnRails.configuration.use_middleware?
         app.middleware.use Middleware
       end


### PR DESCRIPTION
This PR makes sure that middleware is added after `CypressOnRails.configure` is loaded. Now, `use_middleware` configuration option is not working. If the gem is not configured properly, there will be serious security issue.

See: https://guides.rubyonrails.org/configuring.html#initializers