### PR TITLE
Document how to skip installing Cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ bin/rails g cypress_on_rails:install --cypress_folder=test/cypress
 # if you want to install cypress with npm
 bin/rails g cypress_on_rails:install --install_cypress_with=npm
 
+# if you already have cypress installed globally
+bin/rails g cypress_on_rails:install --install_cypress_with=skip
+
 # to update the generated files run
 bin/rails g cypress_on_rails:update
 ```


### PR DESCRIPTION
If the user already has a globally-installed Cypress, they may not want one created in their app's `node_modules` folder (particularly if the Rails app is an API-only backend!)

As passing any value to `install_cypress_with` that isn't `yarn` or `npm` skips installation, I've chosen `skip` here. As long as nobody releases a package manager called `skip` this should be fine 😁