### PR TITLE
Update Generator defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Changed
+* Update default generated folder to cypress instead of spec/cypress
+* Add a generator option to not install cypress
+* generator by default does not include examples
+* default on local to run cypress in development mode
+
 ## [1.8.1]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.8.0...v1.8.1
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ CYPRESS=1 bin/rails server -p 5017
 # in separate window start cypress
 yarn cypress open 
 # or for npm
-node_modules/.bin/cypress run 
+node_modules/.bin/cypress open 
 # or if you changed the cypress folder to spec/cypress
 yarn cypress open --project ./spec
 ```
@@ -121,10 +121,12 @@ How to run cypress on CI
 # ...
 
 yarn run cypress run
-``
-
+# or for npm
+node_modules/.bin/cypress run 
+```
 
 ### Example of using factory bot
+
 You can run your [factory_bot](https://github.com/thoughtbot/factory_bot) directly as well
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ This project is sponsored by the software consulting firm [ShakaCode](https://ww
 
 ----
 
+# Totally new to Cypress?
+Suggest you first learn the basics of Cypress before attempting to integrate with Ruby on Rails
+
+* [Good start Here](https://docs.cypress.io/examples/examples/tutorials.html#Best-Practices)
+
+## Overview
+
 Gem for using [cypress.io](http://github.com/cypress-io/) in Rails and ruby rack applications
 with the goal of controlling State as mentioned in [Cypress Best Practices](https://docs.cypress.io/guides/references/best-practices.html#Organizing-Tests-Logging-In-Controlling-State)
 
@@ -28,7 +35,7 @@ Has examples of setting up state with:
 * [Video of getting started with this gem](https://grant-ps.blog/2018/08/10/getting-started-with-cypress-io-and-ruby-on-rails/)
 * [Article: Introduction to Cypress on Rails](https://www.shakacode.com/blog/introduction-to-cypress-on-rails/)
 
-## Getting started
+## Installation
 
 Add this to your Gemfile:
 
@@ -43,14 +50,14 @@ Generate the boilerplate code using:
 ```shell
 bin/rails g cypress_on_rails:install
 
-# if you have/want a different cypress folder (default is spec/cypress)
-bin/rails g cypress_on_rails:install --cypress_folder=test/cypress
+# if you have/want a different cypress folder (default is cypress)
+bin/rails g cypress_on_rails:install --cypress_folder=spec/cypress
 
 # if you want to install cypress with npm
 bin/rails g cypress_on_rails:install --install_cypress_with=npm
 
 # if you already have cypress installed globally
-bin/rails g cypress_on_rails:install --install_cypress_with=skip
+bin/rails g cypress_on_rails:install --no-install-cypress
 
 # to update the generated files run
 bin/rails g cypress_on_rails:update
@@ -69,22 +76,53 @@ if you are not using factory_bot look at `spec/cypress/app_commands/factory_bot.
 
 Now you can create scenarios and commands that are plain ruby files that get loaded through middleware, the ruby sky is your limit.
 
+### Update your database.yml
+
+When writing cypress test on your local it's recommended to start your server in development mode so that changes you
+make are picked up without having to restart the server. 
+It's recommend you update your database.yml to check if the CYPRESS environment variable is set and switch it to the test database
+otherwise cypress will keep clearing your development database.
+
+for example:
+
+```yaml
+development:
+  <<: *default
+  database: <%= ENV['CYPRESS'] ? 'my_db_test' : 'my_db_development' %>
+test:
+  <<: *default
+  database: my_db_test
+```
+
 ### WARNING
 *WARNING!!:* cypress-on-rails can execute arbitrary ruby code
 Please use with extra caution if starting your local server on 0.0.0.0 or running the gem on a hosted server
 
 ## Usage
 
-Start the rails server in test mode and start cypress
+Getting started on your local environment
 
 ```shell
 # start rails
-RAILS_ENV=test bin/rake db:create db:schema:load
-bin/rails server -e test -p 5017
+CYPRESS=1 bin/rails server -p 5017
 
 # in separate window start cypress
+yarn cypress open 
+# or for npm
+node_modules/.bin/cypress run 
+# or if you changed the cypress folder to spec/cypress
 yarn cypress open --project ./spec
 ```
+
+How to run cypress on CI
+
+```shell
+# setup rails and start server in background
+# ...
+
+yarn run cypress run
+``
+
 
 ### Example of using factory bot
 You can run your [factory_bot](https://github.com/thoughtbot/factory_bot) directly as well

--- a/lib/generators/cypress_on_rails/install_generator.rb
+++ b/lib/generators/cypress_on_rails/install_generator.rb
@@ -1,8 +1,9 @@
 module CypressOnRails
   class InstallGenerator < Rails::Generators::Base
-    class_option :cypress_folder, type: :string, default: 'spec/cypress'
+    class_option :cypress_folder, type: :string, default: 'cypress'
+    class_option :install_cypress, type: :boolean, default: true
     class_option :install_cypress_with, type: :string, default: 'yarn'
-    class_option :install_cypress_examples, type: :boolean, default: true
+    class_option :install_cypress_examples, type: :boolean, default: false
     source_root File.expand_path('../templates', __FILE__)
 
     def install_cypress
@@ -11,14 +12,16 @@ module CypressOnRails
         directories.pop
         install_dir = "#{Dir.pwd}/#{directories.join('/')}"
         command = nil
-        if options.install_cypress_with == 'yarn'
-          command = "yarn --cwd=#{install_dir} add cypress --dev"
-        elsif options.install_cypress_with == 'npm'
-          command = "cd #{install_dir}; npm install cypress --save-dev"
-        end
-        if command
-          say command
-          fail 'failed to install cypress' unless system(command)
+        if options.install_cypress
+          if options.install_cypress_with == 'yarn'
+            command = "yarn --cwd=#{install_dir} add cypress --dev"
+          elsif options.install_cypress_with == 'npm'
+            command = "cd #{install_dir}; npm install cypress --save-dev"
+          end
+          if command
+            say command
+            fail 'failed to install cypress' unless system(command)
+          end
         end
         if options.install_cypress_examples
           directory 'spec/cypress/integration/examples', "#{options.cypress_folder}/integration/examples"
@@ -42,20 +45,6 @@ module CypressOnRails
       append_to_file "#{options.cypress_folder}/support/index.js",
                      "\nimport './on-rails'",
                      after: 'import \'./commands\''
-    end
-
-
-    def update_test_rb
-      if File.exist?('config/environments/test.rb')
-        gsub_file 'config/environments/test.rb',
-                  'config.cache_classes = true',
-                  'config.cache_classes = ENV[\'CI\'].present?'
-      end
-      if File.exist?('spec/dummy/config/environments/test.rb')
-        gsub_file 'spec/dummy/config/environments/test.rb',
-                  'config.cache_classes = true',
-                  'config.cache_classes = ENV[\'CI\'].present?'
-      end
     end
   end
 end

--- a/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
+++ b/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
@@ -3,7 +3,15 @@ if defined?(CypressOnRails)
     c.cypress_folder = File.expand_path("#{__dir__}/../../<%= options.cypress_folder %>")
     # WARNING!! CypressOnRails can execute arbitrary ruby code
     # please use with extra caution if enabling on hosted servers or starting your local server on 0.0.0.0
-    c.use_middleware = Rails.env.test?
+    c.use_middleware = !Rails.env.production?
     c.logger = Rails.logger
   end
+
+  # # if you compile your asssets on CI
+  # if ENV['CYPRESS'].present? && ENV['CI'].present?
+  #  Rails.application.configure do
+  #    config.assets.compile = false
+  #    config.assets.unknown_asset_fallback = false
+  #  end
+  # end
 end

--- a/lib/generators/cypress_on_rails/templates/spec/cypress/cypress_helper.rb
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/cypress_helper.rb
@@ -1,9 +1,14 @@
 # This is loaded once before the first command is executed
 
 begin
- require 'database_cleaner'
+  require 'database_cleaner-active_record'
 rescue LoadError => e
- puts e.message
+  puts e.message
+  begin
+    require 'database_cleaner'
+  rescue LoadError => e
+    puts e.message
+  end
 end
 
 begin

--- a/spec/integrations/rails_3_2/test.sh
+++ b/spec/integrations/rails_3_2/test.sh
@@ -14,7 +14,7 @@ bundle --version
 bundle install --quiet --gemfile="$DIR/Gemfile" --retry 2 --path vendor/bundle
 
 echo '-- cypress install'
-bundle exec ./bin/rails g cypress_on_rails:install --cypress_folder=cypress --install_cypress_with=npm --no-install-cypress-examples
+bundle exec ./bin/rails g cypress_on_rails:install --install_cypress_with=npm
 rm -vf cypress/integration/rails_examples/advance_factory_bot_spec.js
 
 echo '-- start rails server'

--- a/spec/integrations/rails_4_2/test.sh
+++ b/spec/integrations/rails_4_2/test.sh
@@ -14,7 +14,7 @@ bundle --version
 bundle install --quiet --gemfile="$DIR/Gemfile" --retry 2 --path vendor/bundle
 
 echo '-- cypress install'
-bundle exec ./bin/rails g cypress_on_rails:install --no-install-cypress-examples
+bundle exec ./bin/rails g cypress_on_rails:install --cypress_folder=spec/cypress
 rm -vf spec/cypress/integration/rails_examples/advance_factory_bot_spec.js
 
 echo '-- start rails server'

--- a/spec/integrations/rails_5_2/test.sh
+++ b/spec/integrations/rails_5_2/test.sh
@@ -14,7 +14,8 @@ bundle --version
 bundle install --quiet --gemfile="$DIR/Gemfile" --retry 2 --path vendor/bundle
 
 echo '-- migration'
-bin/rails db:migrate
+bundle exec ./bin/rails db:drop || true
+bundle exec ./bin/rails db:create db:migrate
 
 echo '-- cypress install'
 bundle exec ./bin/rails g cypress_on_rails:install --cypress_folder=test/cypress --no-install-cypress-examples


### PR DESCRIPTION
* Update default generated folder to cypress instead of spec/cypress
* Add a generator option to not install cypress (no longer need #70)
* generator by default does not include cypress only examples (closes #48)
* default on local to run cypress in development mode (discussed in #73)