### PR TITLE
Ensure current working directory is consistent

### DIFF
--- a/lib/cypress_on_rails/command_executor.rb
+++ b/lib/cypress_on_rails/command_executor.rb
@@ -11,6 +11,8 @@ module CypressOnRails
       logger.error("fail to execute #{file}: #{e.message}")
       logger.error(e.backtrace.join("\n"))
       raise e
+    ensure
+      Dir.chdir(Rails.root)
     end
 
     def self.load_cypress_helper


### PR DESCRIPTION
While working on some app commands that needed to change the current working directory, I found that _future_ Cypress tests would break because the current working directory had changed during the execution of the script.

I found that resetting the current working directory after executing the commands solved the problem. I thought I would at least share this solution in case anyone else is affected by it, but also adding this "cleanup" seems like a reasonable general-purpose solution.