### PR TITLE
Allow build and build_list commands to be executed against factory bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changed
 * improve app command logging on cypress 
+* Allow build and build_list commands to be executed against factory bot [PR 87](https://github.com/shakacode/cypress-on-rails/pull/87) by [Alexander-Blair]
 
 ## [1.10.1]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.9.1...v1.10.1

--- a/lib/cypress_on_rails/smart_factory_wrapper.rb
+++ b/lib/cypress_on_rails/smart_factory_wrapper.rb
@@ -19,6 +19,14 @@ module CypressOnRails
       instance.create_list(*args)
     end
 
+    def self.build(*args)
+      instance.build(*args)
+    end
+
+    def self.build_list(*args)
+      instance.build_list(*args)
+    end
+
     # @return [Array]
     attr_accessor :factory
     attr_accessor :always_reload
@@ -49,6 +57,22 @@ module CypressOnRails
     def create_list(*args)
       load_files
       factory.create_list(*args)
+    end
+
+    def build(*options)
+      load_files
+      factory_name = options.shift
+      if options.last.is_a?(Hash)
+        args = options.pop
+      else
+        args = {}
+      end
+      factory.build(factory_name, *options.map(&:to_sym), args.symbolize_keys)
+    end
+
+    def build_list(*args)
+      load_files
+      factory.build_list(*args)
     end
 
     private

--- a/spec/cypress_on_rails/smart_factory_wrapper_spec.rb
+++ b/spec/cypress_on_rails/smart_factory_wrapper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CypressOnRails::SmartFactoryWrapper do
   let(:mtime_hash) { {'file1.rb' => time_now, 'file2.rb' => time_now } }
   let(:files) { %w(file1.rb file2.rb) }
   let(:factory_double) do
-    class_double(FactoryBot, create: nil, create_list: nil, "definition_file_paths=": nil, reload: nil)
+    class_double(FactoryBot, create: nil, create_list: nil, build: nil, build_list: nil, "definition_file_paths=": nil, reload: nil)
   end
   let(:kernel_double) { class_double(Kernel, load: true) }
   let(:file_double) { FileSystemDummy.new(mtime_hash) }
@@ -65,6 +65,31 @@ RSpec.describe CypressOnRails::SmartFactoryWrapper do
   it 'it sends delegates create_list to the factory' do
     subject.create_list(:note, 10)
     expect(factory_double).to have_received(:create_list).with(:note, 10)
+  end
+
+  it 'delegates build to the factory' do
+    subject.build(:user)
+    expect(factory_double).to have_received(:build).with(:user, {})
+  end
+
+  it 'delegates build to the factory and symbolize keys' do
+    subject.build(:user, {'name' => "name"})
+    expect(factory_double).to have_received(:build).with(:user, {name: 'name'})
+  end
+
+  it 'delegates build to the factory and symbolize keys with trait' do
+    subject.build(:user, 'trait1', {'name' => "name"})
+    expect(factory_double).to have_received(:build).with(:user, :trait1, {name: 'name'})
+  end
+
+  it 'delegates build to the factory and symbolize keys with only trait' do
+    subject.build(:user, 'trait2')
+    expect(factory_double).to have_received(:build).with(:user, :trait2, {})
+  end
+
+  it 'delegates build_list to the factory' do
+    subject.build_list(:note, 10)
+    expect(factory_double).to have_received(:build_list).with(:note, 10)
   end
 
   it 'wont load the files if they have not changed' do


### PR DESCRIPTION
First of all, thanks for creating this gem! Incredibly useful.

It can be really nice to use FactoryBot to build bodies of HTTP responses dynamically (especially for external services), and even nicer if these can be used by both RSpec and Cypress. A very simple example to demonstrate:
```
FactoryBot.define do
  factory :person_response_body, class: Hash do
    initialize_with { attributes.deep_stringify_keys }

    id { 1 }
    name { 'Mr Blobby' }
    age { 275 }
  end
end
```
It's then possible to call `FactoryBot.build(:person_response_body)`, generating a Ruby hash (with all the flexibility that factory bot gives us). This can then be passed to a Cypress mock, in the same way you could do with a Cypress fixture.