### PR TITLE
Explicitly set `Accept` / `Content-Type` headers to `application/json`

### DIFF
--- a/lib/generators/cypress_on_rails/templates/spec/cypress/support/on-rails.js
+++ b/lib/generators/cypress_on_rails/templates/spec/cypress/support/on-rails.js
@@ -7,7 +7,11 @@ Cypress.Commands.add('appCommands', function (body) {
     url: "/__cypress__/command",
     body: JSON.stringify(body),
     log: false,
-    failOnStatusCode: false
+    failOnStatusCode: false,
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    }
   }).then((response) => {
     log.end();
     if (response.status !== 201) {


### PR DESCRIPTION
Was having this JSON parsing issue when using `cy.appScenario` with an argument that contains a string with a percent sign in it (e.g. `cy.appScenario('some_thing', { my_param: "%" })`)

<img width="604" alt="image" src="https://user-images.githubusercontent.com/64985/148465751-61d8f88c-e7b9-4586-a4c1-da54bb86cbe3.png">

Explicitly setting the `Accept` / `Content-Type` headers to `application/json` seems to have fixed it.