### PR TITLE
Properly copies the cypress_helper file when running the update generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Fixed
+* Properly copies the cypress_helper file when running the update generator [PR 117](https://github.com/shakacode/cypress-on-rails/pull/117) by [alvincrespo]
+
 ### Tasks
 * pass cypress record key to github action [PR 110](https://github.com/shakacode/cypress-on-rails/pull/110)
 

--- a/lib/generators/cypress_on_rails/update_generator.rb
+++ b/lib/generators/cypress_on_rails/update_generator.rb
@@ -5,7 +5,7 @@ module CypressOnRails
 
     def update_generated_files
       template "config/initializers/cypress_on_rails.rb.erb", "config/initializers/cypress_on_rails.rb"
-      copy_file "spec/cypress/cypress_helper.rb", "#{options.cypress_folder}/cypress_helper.rb"
+      template "spec/cypress/cypress_helper.erb.rb", "#{options.cypress_folder}/cypress_helper.rb"
       copy_file "spec/cypress/support/on-rails.js", "#{options.cypress_folder}/support/on-rails.js"
       directory 'spec/cypress/app_commands', "#{options.cypress_folder}/app_commands"
     end


### PR DESCRIPTION
When running the update generator I was receiving the following error:

```sh
bundle exec rails g cypress_on_rails:update                    
Could not find "spec/cypress/cypress_helper.rb" in any of your source paths. Your current source paths are: 
/Users/alvincrespo/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/cypress-on-rails-1.13.1/lib/generators/cypress_on_rails/templates
```

This error was being received because the `copy_file` method was looking for the `cypress_helper.rb` file and not the `cypress_helper.erb.rb` file. To fix this we need to use `template` so that the file can be copied as well as compiled against the appropriate options. 