### PR TITLE
Add an api_prefix option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ### Changed
-* Add support for proxy routes through `api_prefix` [PR 130](https://github.com/shakacode/cypress-on-rails/pull/130)
-
-## [1.14.0]
-[Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.13.1...v1.14.0
+* Add support for proxy routes through `api_prefix` [PR 130](https://github.com/shakacode/cypress-on-rails/pull/130) by [RomainEndelin]
 
 ### Fixed
 * Properly copies the cypress_helper file when running the update generator [PR 117](https://github.com/shakacode/cypress-on-rails/pull/117) by [alvincrespo]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Changed
+* Add support for api_prefix [PR 130](https://github.com/shakacode/cypress-on-rails/pull/130)
+
+## [1.14.0]
+[Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.13.1...v1.14.0
+
 ### Fixed
 * Properly copies the cypress_helper file when running the update generator [PR 117](https://github.com/shakacode/cypress-on-rails/pull/117) by [alvincrespo]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Changed
-* Add support for api_prefix [PR 130](https://github.com/shakacode/cypress-on-rails/pull/130)
+* Add support for proxy routes through `api_prefix` [PR 130](https://github.com/shakacode/cypress-on-rails/pull/130)
 
 ## [1.14.0]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.13.1...v1.14.0
@@ -46,7 +46,7 @@
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.10.1...v1.11.0
 
 ### Changed
-* improve app command logging on cypress 
+* improve app command logging on cypress
 * Allow build and build_list commands to be executed against factory bot [PR 87](https://github.com/shakacode/cypress-on-rails/pull/87) by [Alexander-Blair]
 
 ## [1.10.1]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ bin/rails g cypress_on_rails:install
 # if you have/want a different cypress folder (default is cypress)
 bin/rails g cypress_on_rails:install --cypress_folder=spec/cypress
 
+# if you target the Rails server with a path prefix to your URL
+bin/rails g cypress_on_rails:install --api_prefix=/api
+
 # if you want to install cypress with npm
 bin/rails g cypress_on_rails:install --install_cypress_with=npm
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ----
 
-This project is sponsored by the software consulting firm [ShakaCode](https://www.shakacode.com), creator of the [React on Rails Gem](https://github.com/shakacode/react_on_rails). We focus on React (with TS or ReScript) front-ends, often with Ruby on Rails or Gatsby. See [our recent work](https://www.shakacode.com/recent-work) and [client engagement model](https://www.shakacode.com/blog/client-engagement-model/). Feel free to engage in discussions around this gem at our [Slack Channel](https://join.slack.com/t/reactrails/shared_invite/enQtNjY3NTczMjczNzYxLTlmYjdiZmY3MTVlMzU2YWE0OWM0MzNiZDI0MzdkZGFiZTFkYTFkOGVjODBmOWEyYWQ3MzA2NGE1YWJjNmVlMGE) or our [forum category for Cypress](https://forum.shakacode.com/c/cypress-on-rails/55). 
+This project is sponsored by the software consulting firm [ShakaCode](https://www.shakacode.com), creator of the [React on Rails Gem](https://github.com/shakacode/react_on_rails). We focus on React (with TS or ReScript) front-ends, often with Ruby on Rails or Gatsby. See [our recent work](https://www.shakacode.com/recent-work) and [client engagement model](https://www.shakacode.com/blog/client-engagement-model/). Feel free to engage in discussions around this gem at our [Slack Channel](https://join.slack.com/t/reactrails/shared_invite/enQtNjY3NTczMjczNzYxLTlmYjdiZmY3MTVlMzU2YWE0OWM0MzNiZDI0MzdkZGFiZTFkYTFkOGVjODBmOWEyYWQ3MzA2NGE1YWJjNmVlMGE) or our [forum category for Cypress](https://forum.shakacode.com/c/cypress-on-rails/55).
 
 Interested in joining a small team that loves open source? Check our [careers page](https://www.shakacode.com/career/).
 
@@ -88,7 +88,7 @@ Now you can create scenarios and commands that are plain Ruby files that get loa
 ### Update your database.yml
 
 When running `cypress test` on your local computer it's recommended to start your server in development mode so that changes you
-make are picked up without having to restart the server. 
+make are picked up without having to restart the server.
 It's recommended you update your `database.yml` to check if the `CYPRESS` environment variable is set and switch it to the test database
 otherwise cypress will keep clearing your development database.
 
@@ -115,9 +115,9 @@ Getting started on your local environment
 CYPRESS=1 bin/rails server -p 5017
 
 # in separate window start cypress
-yarn cypress open 
+yarn cypress open
 # or for npm
-node_modules/.bin/cypress open 
+node_modules/.bin/cypress open
 # or if you changed the cypress folder to spec/cypress
 yarn cypress open --project ./spec
 ```
@@ -130,7 +130,7 @@ How to run cypress on CI
 
 yarn run cypress run
 # or for npm
-node_modules/.bin/cypress run 
+node_modules/.bin/cypress run
 ```
 
 ### Example of using factory bot
@@ -397,6 +397,17 @@ Cypress.Commands.add('appFactories', (options) => {
 beforeEach(() => {
   cy.app('clean') // have a look at cypress/app_commands/clean.rb
 });
+```
+
+## API Prefix
+
+If your Rails server is exposed under a proxy, typically https://my-local.dev/api, you can use the `api_prefix` option.
+In `config/initializers/cypress_on_rails.rb`, add this line:
+```ruby
+  CypressOnRails.configure do |c|
+    # ...
+    c.api_prefix = '/api'
+  end
 ```
 
 ## Contributing

--- a/lib/cypress_on_rails/configuration.rb
+++ b/lib/cypress_on_rails/configuration.rb
@@ -3,6 +3,7 @@ require 'logger'
 module CypressOnRails
   class Configuration
     attr_accessor :cypress_folder
+    attr_accessor :api_prefix
     attr_accessor :use_middleware
     attr_accessor :use_vcr_middleware
     attr_accessor :logger
@@ -16,6 +17,7 @@ module CypressOnRails
 
     def reset
       self.cypress_folder = 'spec/cypress'
+      self.api_prefix = ''
       self.use_middleware = true
       self.use_vcr_middleware = false
       self.logger = Logger.new(STDOUT)

--- a/lib/cypress_on_rails/middleware.rb
+++ b/lib/cypress_on_rails/middleware.rb
@@ -16,7 +16,7 @@ module CypressOnRails
 
     def call(env)
       request = Rack::Request.new(env)
-      if request.path.start_with?('/__cypress__/command')
+      if request.path.start_with?("#{configuration.api_prefix}/__cypress__/command")
         configuration.tagged_logged { handle_command(request) }
       else
         @app.call(env)

--- a/lib/cypress_on_rails/version.rb
+++ b/lib/cypress_on_rails/version.rb
@@ -1,3 +1,3 @@
 module CypressOnRails
-  VERSION = '1.13.1'.freeze
+  VERSION = '1.14.0'.freeze
 end

--- a/lib/cypress_on_rails/version.rb
+++ b/lib/cypress_on_rails/version.rb
@@ -1,3 +1,3 @@
 module CypressOnRails
-  VERSION = '1.14.0'.freeze
+  VERSION = '1.13.1'.freeze
 end

--- a/lib/generators/cypress_on_rails/install_generator.rb
+++ b/lib/generators/cypress_on_rails/install_generator.rb
@@ -1,6 +1,7 @@
 module CypressOnRails
   class InstallGenerator < Rails::Generators::Base
     class_option :cypress_folder, type: :string, default: 'cypress'
+    class_option :api_prefix, type: :string, default: ''
     class_option :install_cypress, type: :boolean, default: true
     class_option :install_cypress_with, type: :string, default: 'yarn'
     class_option :experimental, type: :boolean, default: false

--- a/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
+++ b/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
@@ -5,6 +5,7 @@ if defined?(CypressOnRails)
     # please use with extra caution if enabling on hosted servers or starting your local server on 0.0.0.0
     c.use_middleware = !Rails.env.production?
     <% unless options.experimental %># <% end %> c.use_vcr_middleware = !Rails.env.production?
+    c.api_prefix = <%= options.api_prefix %>
     c.logger = Rails.logger
   end
 

--- a/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
+++ b/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
@@ -5,7 +5,7 @@ if defined?(CypressOnRails)
     # please use with extra caution if enabling on hosted servers or starting your local server on 0.0.0.0
     c.use_middleware = !Rails.env.production?
     <% unless options.experimental %># <% end %> c.use_vcr_middleware = !Rails.env.production?
-    c.api_prefix = <%= options.api_prefix %>
+    c.api_prefix = "<%= options.api_prefix %>"
     c.logger = Rails.logger
   end
 

--- a/spec/cypress_on_rails/configuration_spec.rb
+++ b/spec/cypress_on_rails/configuration_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CypressOnRails::Configuration do
     CypressOnRails.configure { |config| config.reset }
 
     expect(CypressOnRails.configuration.cypress_folder).to eq('spec/cypress')
+    expect(CypressOnRails.configuration.api_prefix).to eq('')
     expect(CypressOnRails.configuration.use_middleware?).to eq(true)
     expect(CypressOnRails.configuration.logger).to_not be_nil
   end
@@ -13,10 +14,12 @@ RSpec.describe CypressOnRails::Configuration do
     my_logger = Logger.new(STDOUT)
     CypressOnRails.configure do |config|
       config.cypress_folder = 'my/path'
+      config.cypress_folder = '/api'
       config.use_middleware = false
       config.logger = my_logger
     end
     expect(CypressOnRails.configuration.cypress_folder).to eq('my/path')
+    expect(CypressOnRails.configuration.cypress_folder).to eq('/')
     expect(CypressOnRails.configuration.use_middleware?).to eq(false)
     expect(CypressOnRails.configuration.logger).to eq(my_logger)
   end

--- a/spec/cypress_on_rails/configuration_spec.rb
+++ b/spec/cypress_on_rails/configuration_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe CypressOnRails::Configuration do
     my_logger = Logger.new(STDOUT)
     CypressOnRails.configure do |config|
       config.cypress_folder = 'my/path'
-      config.cypress_folder = '/api'
+      config.api_prefix = '/api'
       config.use_middleware = false
       config.logger = my_logger
     end
     expect(CypressOnRails.configuration.cypress_folder).to eq('my/path')
-    expect(CypressOnRails.configuration.cypress_folder).to eq('/')
+    expect(CypressOnRails.configuration.api_prefix).to eq('/api')
     expect(CypressOnRails.configuration.use_middleware?).to eq(false)
     expect(CypressOnRails.configuration.logger).to eq(my_logger)
   end


### PR DESCRIPTION
We have a Rails server is exposed under a proxy, typically https://my-local.dev/api.
It didn't work because the middleware was looking for `/__cypress__/commands`.

This PR supports an `api_prefix` proxy, so that we can target https://my-local.dev/api/__cypress__/commands