### PR TITLE
Remove cypress_folder deprecation warning

### DIFF
--- a/lib/cypress_on_rails/configuration.rb
+++ b/lib/cypress_on_rails/configuration.rb
@@ -10,9 +10,9 @@ module CypressOnRails
 
     # Attributes for backwards compatibility
     def cypress_folder
-      warn "cypress_folder is deprecated, please use install_folder"
       install_folder
     end
+
     def cypress_folder=(v)
       warn "cypress_folder= is deprecated, please use install_folder"
       self.install_folder = v


### PR DESCRIPTION
This is a side effect of this PR #131.

`cypress_folder` was deprecated and is now returning a deprecation warning saying that `cypress_folder is deprecated, please use install_folder`.

This change is filling the logs with the above warning message because it's used internally for backward compatibility, and it can be confirmed by running the test cases in this repo.

<img width="590" alt="Screenshot 2023-07-19 at 13 04 37" src="https://github.com/shakacode/cypress-on-rails/assets/4639990/d784af54-4abf-4bc7-b8c4-d8fa727cd9c1">


I believe that only the writer method should show a warning when used in the configuration, therefore creating this pull request to remove the warning from `cypress_folder`. 