### PR TITLE
fix cypress_folder deprecation warning by internal code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Fixed
+* fix cypress_folder deprecation warning by internal code [PR 136](https://github.com/shakacode/cypress-on-rails/pull/136)
+
 ## [1.15.0]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.14.0...v1.15.0
 

--- a/lib/cypress_on_rails/command_executor.rb
+++ b/lib/cypress_on_rails/command_executor.rb
@@ -15,12 +15,12 @@ module CypressOnRails
 
     def self.load_e2e_helper
       e2e_helper_file = "#{configuration.install_folder}/e2e_helper.rb"
-      cypress_helper_file = "#{configuration.cypress_folder}/cypress_helper.rb"
+      cypress_helper_file = "#{configuration.install_folder}/cypress_helper.rb"
       if File.exist?(e2e_helper_file)
         Kernel.require e2e_helper_file
       elsif File.exist?(cypress_helper_file)
         Kernel.require cypress_helper_file
-        warn "cypress_helper.rb and cypress_folder are deprecated, please use the install generator to create e2e_helper.rb using install_folder"
+        warn "cypress_helper.rb is deprecated, please rename the file e2e_helper.rb"
       else
         logger.warn "could not find #{e2e_helper_file} nor #{cypress_helper_file}"
       end

--- a/lib/cypress_on_rails/command_executor.rb
+++ b/lib/cypress_on_rails/command_executor.rb
@@ -20,7 +20,7 @@ module CypressOnRails
         Kernel.require e2e_helper_file
       elsif File.exist?(cypress_helper_file)
         Kernel.require cypress_helper_file
-        warn "cypress_helper.rb is deprecated, please rename the file e2e_helper.rb"
+        warn "cypress_helper.rb is deprecated, please rename the file to e2e_helper.rb"
       else
         logger.warn "could not find #{e2e_helper_file} nor #{cypress_helper_file}"
       end


### PR DESCRIPTION
internal code should use the new `install_folder` instead of the old `cypress_folder` method.

