### PR TITLE
Introduce before_request configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## [1.16.0]
-[Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.15.1...v1.16.0
-
 ### Added
 * Add support for `before_request` options on the middleware, for authentication [PR 138](https://github.com/shakacode/cypress-on-rails/pull/138) by [RomainEndelin]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.16.0]
+[Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.15.1...v1.16.0
+
+### Added
+* Add support for `before_request` options on the middleware, for authentication [PR 138](https://github.com/shakacode/cypress-on-rails/pull/138) by [RomainEndelin]
+
 ## [1.15.1]
 [Compare]: https://github.com/shakacode/cypress-on-rails/compare/v1.15.0...v1.15.1
 

--- a/lib/cypress_on_rails/configuration.rb
+++ b/lib/cypress_on_rails/configuration.rb
@@ -6,6 +6,7 @@ module CypressOnRails
     attr_accessor :install_folder
     attr_accessor :use_middleware
     attr_accessor :use_vcr_middleware
+    attr_accessor :before_request
     attr_accessor :logger
 
     # Attributes for backwards compatibility
@@ -30,6 +31,7 @@ module CypressOnRails
       self.install_folder = 'spec/e2e'
       self.use_middleware = true
       self.use_vcr_middleware = false
+      self.before_request = -> (request) {}
       self.logger = Logger.new(STDOUT)
     end
 

--- a/lib/cypress_on_rails/middleware.rb
+++ b/lib/cypress_on_rails/middleware.rb
@@ -47,6 +47,10 @@ module CypressOnRails
     end
 
     def handle_command(req)
+      maybe_env = configuration.before_request.call(req)
+      # Halt the middleware if an Rack Env was returned by `before_request`
+      return maybe_env unless maybe_env.nil?
+
       body = JSON.parse(req.body.read)
       logger.info "handle_command: #{body}"
       commands = Command.from_body(body, configuration)

--- a/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
+++ b/lib/generators/cypress_on_rails/templates/config/initializers/cypress_on_rails.rb.erb
@@ -7,6 +7,15 @@ if defined?(CypressOnRails)
     c.use_middleware = !Rails.env.production?
     <% unless options.experimental %># <% end %> c.use_vcr_middleware = !Rails.env.production?
     c.logger = Rails.logger
+
+    # If you want to enable a before_request logic, such as authentication, logging, sending metrics, etc.
+    #   Refer to https://www.rubydoc.info/gems/rack/Rack/Request for the `request` argument.
+    #   Return nil to continue through the Cypress command. Return a response [status, header, body] to halt.
+    # c.before_request = lambda { |request|
+    #   unless request.env['warden'].authenticate(:secret_key)
+    #     return [403, {}, ["forbidden"]]
+    #   end
+    # }
   end
 
   # # if you compile your asssets on CI

--- a/spec/cypress_on_rails/configuration_spec.rb
+++ b/spec/cypress_on_rails/configuration_spec.rb
@@ -8,19 +8,23 @@ RSpec.describe CypressOnRails::Configuration do
     expect(CypressOnRails.configuration.install_folder).to eq('spec/e2e')
     expect(CypressOnRails.configuration.use_middleware?).to eq(true)
     expect(CypressOnRails.configuration.logger).to_not be_nil
+    expect(CypressOnRails.configuration.before_request).to_not be_nil
   end
 
   it 'can be configured' do
     my_logger = Logger.new(STDOUT)
+    before_request_lambda = -> (_) { return [200, {}, ['hello world']] }
     CypressOnRails.configure do |config|
       config.api_prefix = '/api'
       config.install_folder = 'my/path'
       config.use_middleware = false
       config.logger = my_logger
+      config.before_request = before_request_lambda
     end
     expect(CypressOnRails.configuration.api_prefix).to eq('/api')
     expect(CypressOnRails.configuration.install_folder).to eq('my/path')
     expect(CypressOnRails.configuration.use_middleware?).to eq(false)
     expect(CypressOnRails.configuration.logger).to eq(my_logger)
+    expect(CypressOnRails.configuration.before_request).to eq(before_request_lambda)
   end
 end


### PR DESCRIPTION
Discussed in #137 

Add a `before_request: -> (env) { ... }` configuration option. This option can be useful for users to authenticate their calls, add metrics, etc.