### PR TITLE
Update README to suggest content type with rails 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,9 @@ Cypress.Commands.add('appCommands', (body) => {
     method: 'POST',
     url: '/__cypress__/command',
     body: JSON.stringify(body),
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
     log: true,
     failOnStatusCode: true
   })


### PR DESCRIPTION
I had the same issue as #141 and I was looking everywhere for a solution

I figured it was a good thing to add it to. the README