### PR TITLE
Specify paths with Rails.root.join

### DIFF
--- a/lib/cypress_on_rails/command_executor.rb
+++ b/lib/cypress_on_rails/command_executor.rb
@@ -14,8 +14,8 @@ module CypressOnRails
     end
 
     def self.load_e2e_helper
-      e2e_helper_file = "#{configuration.install_folder}/e2e_helper.rb"
-      cypress_helper_file = "#{configuration.install_folder}/cypress_helper.rb"
+      e2e_helper_file = Rails.root.join(configuration.install_folder, "e2e_helper.rb")
+      cypress_helper_file = Rails.root.join(configuration.install_folder, "cypress_helper.rb")
       if File.exist?(e2e_helper_file)
         Kernel.require e2e_helper_file
       elsif File.exist?(cypress_helper_file)


### PR DESCRIPTION
Starting in v1.16.0 the e2e_helper.rb file could only be found when I ran cypress in headless mode.
This shouldn't have been the problem, but GUI mode worked after I changed it, and seems like a better way to specify paths.