### PR TITLE
Update Control Plane link

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ In `config/initializers/cypress_on_rails.rb`, add this line:
     <img alt="ScoutAPM" src="https://user-images.githubusercontent.com/4244251/184881152-9f2d8fba-88ac-4ba6-873b-22387f8711c5.png" height="120px">
   </picture>
 </a>
-<a href="https://controlplane.com">
+<a href="https://shakacode.controlplane.com">
   <picture>
     <img alt="Control Plane" src="https://github.com/shakacode/.github/assets/20628911/90babd87-62c4-4de3-baa4-3d78ef4bec25" height="120px">
   </picture>


### PR DESCRIPTION
Updates the README so the Control Plane link goes to our landing page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated URL in the configuration documentation to reflect the new domain: `https://shakacode.controlplane.com`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->