### PR TITLE
Added Playwright examples to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ npx cypress run --project ./e2e
 
 You can run your [factory_bot](https://github.com/thoughtbot/factory_bot) directly as well
 
+then in Cypress
 ```js
 // spec/cypress/e2e/simple.cy.js
 describe('My First Test', () => {
@@ -195,6 +196,32 @@ describe('My First Test', () => {
   })
 })
 ```
+
+then in Playwright
+```js
+const { test, expect, request } = require('@playwright/test');
+
+test.describe('My First Test', () => {
+    test('visit root', async ({ page }) => {
+        // This calls to the backend to prepare the application state
+        await appFactories([
+            ['create_list', 'post', 10],
+            ['create', 'post', { title: 'Hello World' }],
+            ['create', 'post', 'with_comments', { title: 'Factory_bot Traits here' }] // использование traits
+        ]);
+
+        // Visit the application under test
+        await page.goto('/');
+        
+        await expect(page).toHaveText('Hello World');
+
+        // Accessing result
+        const records = await appFactories([['create', 'invoice', { paid: false }]]);
+        await page.goto(`/invoices/${records[0].id}`);
+    });
+});
+```
+
 You can check the [association docs](docs/factory_bot_associations.md) on more ways to setup association with the correct data.
 
 In some cases, using static Cypress fixtures may not provide sufficient flexibility when mocking HTTP response bodies. It's possible to use `FactoryBot.build` to generate Ruby hashes that can then be used as mock JSON responses:
@@ -507,6 +534,47 @@ Cypress.Commands.add('appFactories', (options) => {
 beforeEach(() => {
   cy.app('clean') // have a look at cypress/app_commands/clean.rb
 });
+```
+
+add the following file to Playwright
+```js
+// test/playwright/support/on-rails.js
+async function appCommands(body) {
+    const context = await request.newContext();
+    const response = await context.post('/__e2e__/command', {
+        data: body,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+
+    if (response.status() !== 201) {
+        const responseBody = await response.text();
+        console.error(`Error body: ${responseBody}`);
+        throw new Error(`Expected status 201 but got ${response.status()} - ${responseBody}`);
+    }
+
+    return response.json();
+}
+
+async function app(name, commandOptions = {}) {
+    const body = await appCommands({ name, options: commandOptions });
+    return body[0];
+}
+
+async function appScenario(name, options = {}) {
+    const body = { name: `scenarios/${name}`, options };
+    const result = await appCommands(body);
+    return result[0];
+}
+
+async function appFactories(options) {
+    return app('factory_bot', options);
+}
+
+async function clean() {
+    await app('clean');
+}
 ```
 
 ## API Prefix

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ test.describe('My First Test', () => {
         await appFactories([
             ['create_list', 'post', 10],
             ['create', 'post', { title: 'Hello World' }],
-            ['create', 'post', 'with_comments', { title: 'Factory_bot Traits here' }] // использование traits
+            ['create', 'post', 'with_comments', { title: 'Factory_bot Traits here' }]
         ]);
 
         // Visit the application under test
@@ -550,7 +550,6 @@ async function appCommands(body) {
 
     if (response.status() !== 201) {
         const responseBody = await response.text();
-        console.error(`Error body: ${responseBody}`);
         throw new Error(`Expected status 201 but got ${response.status()} - ${responseBody}`);
     }
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -56,15 +56,23 @@ In `playwright/support/on-rails.js`:
 
 ```js
 async function forceLogin(page, { email, redirect_to = '/' }) {
+    // Validate inputs
+    if (!email || typeof email !== 'string' || !redirect_to || typeof redirect_to !== 'string') {
+        throw new Error('Invalid input: email and redirect_to must be non-empty strings');
+    }
+
     const response = await page.request.post('/__e2e__/force_login', {
         data: { email: email, redirect_to: redirect_to },
         headers: { 'Content-Type': 'application/json' }
     });
 
+    // Handle response based on status code
     if (response.ok()) {
         await page.goto(redirect_to);
     } else {
         console.error(`Login failed with status: ${response.status()}`);
+        // Throw an exception for specific error statuses
+        throw new Error(`Login failed with status: ${response.status()}`);
     }
 }
 ```

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -53,6 +53,7 @@ cy.forceLogin({email: 'someuser@mail.com'})
 ```
 
 In `playwright/support/on-rails.js`:
+
 ```js
 async function forceLogin(page, { email, redirect_to }) {
     const context = await request.newContext();
@@ -68,7 +69,12 @@ async function forceLogin(page, { email, redirect_to }) {
     });
 
     if (response.ok()) {
-        const storageState = await context.storageState();
+        let storageState;
+        try{
+            storageState = await context.storageState();
+        } catch (error) {
+            throw new Error(`Error parsing storage state: ${error.message}`);
+        }
         await page.context().addCookies(storageState.cookies);
         await page.goto(redirect_to);
         return { cookies: storageState.cookies, context };

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -57,7 +57,7 @@ In `playwright/support/on-rails.js`:
 ```js
 async function forceLogin(page, { email, redirect_to = '/' }) {
     // Validate inputs
-    if (!email || typeof email !== 'string' || !redirect_to || typeof redirect_to !== 'string') {
+    if (typeof email !== 'string'  || typeof redirect_to !== 'string') {
         throw new Error('Invalid input: email and redirect_to must be non-empty strings');
     }
 
@@ -70,7 +70,6 @@ async function forceLogin(page, { email, redirect_to = '/' }) {
     if (response.ok()) {
         await page.goto(redirect_to);
     } else {
-        console.error(`Login failed with status: ${response.status()}`);
         // Throw an exception for specific error statuses
         throw new Error(`Login failed with status: ${response.status()}`);
     }

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -56,17 +56,27 @@ In `playwright/support/on-rails.js`:
 
 ```js
 async function forceLogin(page, { email, redirect_to }) {
-    const context = await request.newContext();
+    if (!isValidEmail(email)) {
+        throw new Error(`Invalid email format: ${email}`);
+    }
+    
+    if (!isValidUrl(redirect_to)) {
+        throw new Error(`Invalid redirect URL: ${redirect_to}`);
+    }
 
-    const response = await context.post('/__e2e__/force_login', {
-        data: JSON.stringify({
-            email: email,
-            redirect_to: redirect_to
-        }),
-        headers: {
-            'Content-Type': 'application/json'
-        }
-    });
+    const context = await request.newContext();
+    let response;
+
+    try {
+        response = await context.post('/__e2e__/force_login', {
+            data: JSON.stringify({ email, redirect_to }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        });
+    } catch (error) {
+        throw new Error(`Request failed: ${error.message}`);
+    }
 
     if (response.ok()) {
         let storageState;

--- a/docs/factory_bot_associations.md
+++ b/docs/factory_bot_associations.md
@@ -55,10 +55,12 @@ cy.appFactories([['create', 'author']]).then((records) => {
 ```
 
 then in Playwright
+There are a few ways you can set up associations with the correct data using Playwright and FactoryBot.
 ```js
 const records = await appFactories([['create', 'author', { name: 'James' }]], context);
 await appFactories([['create', 'post', { title: 'Playwright is cool', author_id: records[0].id }]], context);
 ```
+// Note: These Playwright examples demonstrate asynchronous interactions with the server for setting up data associations. Ensure that your environment is configured to handle these async operations.
 
 
 ## 2. Using transient attributes

--- a/docs/factory_bot_associations.md
+++ b/docs/factory_bot_associations.md
@@ -59,8 +59,8 @@ There are a few ways you can set up associations with the correct data using Pla
 ```js
 const records = await appFactories([['create', 'author', { name: 'James' }]], context);
 await appFactories([['create', 'post', { title: 'Playwright is cool', author_id: records[0].id }]], context);
-```
 // Note: These Playwright examples demonstrate asynchronous interactions with the server for setting up data associations. Ensure that your environment is configured to handle these async operations.
+```
 
 
 ## 2. Using transient attributes

--- a/docs/factory_bot_associations.md
+++ b/docs/factory_bot_associations.md
@@ -54,6 +54,13 @@ cy.appFactories([['create', 'author']]).then((records) => {
 })
 ```
 
+then in Playwright
+```js
+const records = await appFactories([['create', 'author', { name: 'James' }]], context);
+await appFactories([['create', 'post', { title: 'Playwright is cool', author_id: records[0].id }]], context);
+```
+
+
 ## 2. Using transient attributes
 
 ```rb
@@ -79,6 +86,11 @@ cy.appFactories([['create', 'post', { title: 'Cypress is cool', author_name: 'Ja
 
 // example without overriding
 cy.appFactories([['create', 'post']])
+```
+
+then in Playwright
+```js
+const records = await appFactories([['create', 'post', { title: 'Playwright is cool', author_name: 'James' }]]);
 ```
 
 ## 3. Using Nested Attributes


### PR DESCRIPTION
We are transitioning from Cypress to Playwright, and I decided to add examples to the documentation. 
Hopefully, this will help someone:)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced Playwright integration, including test setup, utility functions, and API request handling.
  - Added new `forceLogin` function for authentication in Playwright, allowing users to log in and navigate to specified pages.

- **Documentation**
  - Updated `docs/authentication.md` and `docs/factory_bot_associations.md` with Playwright code snippets and examples, enhancing the documentation for user authentication and record creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->